### PR TITLE
[Fix] Item Status

### DIFF
--- a/TeamNotionOrigin/Assets/@Scripts/Data/Item.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Data/Item.cs
@@ -26,7 +26,6 @@ namespace Data {
         public string name;
         public string description;
         public float cost;
-        public List<StatModifier> modifiers;
     }
 
     [System.Serializable]

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Creatures/Creature.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Creatures/Creature.cs
@@ -107,7 +107,7 @@ public class Creature : MonoBehaviour {
     }
 
     public virtual void SetInventory() {
-        Inventory = new();
+        Inventory = new(this);
         Inventory.Gold += Data.gold;
     }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Creatures/Player.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Creatures/Player.cs
@@ -5,7 +5,13 @@ using UnityEngine.InputSystem;
 
 public class Player : Creature {
 
+    #region Properties
+
     public override string AnimatorName => "Character";
+
+    public Weapon CurrentWeapon => (Inventory as PlayerInventory).EquippedWeapon;
+
+    #endregion
 
     public override bool Initialize() {
         if (!base.Initialize()) return false;
@@ -18,7 +24,7 @@ public class Player : Creature {
     }
 
     public override void SetInventory() {
-        Inventory = new PlayerInventory();
+        Inventory = new PlayerInventory(this);
         Inventory.Gold += Data.gold;
     }
 

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Inventory/Inventory.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Inventory/Inventory.cs
@@ -8,6 +8,7 @@ public class Inventory {
 
     #region Properties
 
+    public Creature Owner { get; private set; }
     public float Gold {
         get => _gold;
         set {
@@ -33,12 +34,29 @@ public class Inventory {
 
     #endregion
 
+    public Inventory(Creature owner) => Owner = owner;
+
     public void Add(Item item) {
         _items.Add(item);
+        item.Owner = this.Owner;
+
+        if (item is PassiveItem passiveItem) {
+            Owner.Status.AddModifiers(passiveItem.Modifiers);
+        }
+        else if (item is Weapon weapon && this is PlayerInventory playerInventory) {
+            playerInventory.AddWeapon(weapon);
+        }
         OnChanged?.Invoke();
     }
     public void Remove(Item item) {
         _items.Remove(item);
+        if (item is PassiveItem passiveItem) {
+            Owner.Status.RemoveModifiers(passiveItem.Modifiers);
+        }
+        else if (item is Weapon weapon && this is PlayerInventory playerInventory) {
+            playerInventory.RemoveWeapon(weapon);
+        }
+        item.Owner = null;
         OnChanged?.Invoke();
     }
     public Item GetItemIndex(int index) => index < _items.Count ? _items[index] : null;

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Inventory/PlayerInventory.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Inventory/PlayerInventory.cs
@@ -12,18 +12,57 @@ public class PlayerInventory : Inventory {
         set {
             if (value == _equippedWeapon) return;
             else if (value != null) {
-                GameObject.FindObjectOfType<Player>().Status.AddModifiers(value.Modifiers);     // TODO:: Find 제거
+                Owner.Status.AddModifiers(value.Modifiers);
                 _equippedWeapon = value;
                 OnEquipChanged?.Invoke(_equippedWeapon);
             }
             else {
-                GameObject.FindObjectOfType<Player>().Status.RemoveModifiers(value.Modifiers);  // TODO:: Find 제거
+                Owner.Status.RemoveModifiers(value.Modifiers);
                 OnEquipChanged.Invoke(_equippedWeapon);
                 _equippedWeapon = null;
             }
         }
     }
 
+    private readonly int MaxWeaponCount = 3;
+    private List<Weapon> _weapons = new();
     private Weapon _equippedWeapon;
 
+    public PlayerInventory(Creature creature) : base(creature) { }
+
+    public bool AddWeapon(Weapon weapon) {
+        if (_weapons.Count >= MaxWeaponCount) return false;
+        _weapons.Add(weapon);
+        if (EquippedWeapon == null) EquipWeapon(0);
+        return true;
+    }
+    public bool RemoveWeapon(Weapon weapon) {
+        if (_weapons.Count == 0 || !_weapons.Contains(weapon)) return false;
+        return _weapons.Remove(weapon);
+    }
+    public void EquipWeapon(int index) {
+        if (index >= _weapons.Count) return;
+
+        EquippedWeapon = _weapons[index];
+    }
+    public void EquipNextWeapon() {
+        if (EquippedWeapon == null) {
+            if (_weapons.Count == 0) return;
+            EquipWeapon(0);
+            return;
+        }
+        int index = _weapons.IndexOf(EquippedWeapon) + 1;
+        if (index >= _weapons.Count) index = 0;
+        EquipWeapon(index);
+    }
+    public void EquipPrevWeapon() {
+        if (EquippedWeapon == null) {
+            if (_weapons.Count == 0) return;
+            EquipWeapon(0);
+            return;
+        }
+        int index = _weapons.IndexOf(EquippedWeapon) - 1;
+        if (index <= 0) index = _weapons.Count - 1;
+        EquipWeapon(index);
+    }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/Item.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/Item.cs
@@ -4,14 +4,53 @@ using UnityEngine;
 
 public class Item : MonoBehaviour {
 
+    #region Properties
+
+    public Creature Owner { get; set; }
     public Data.Item Data { get; private set; }
     public int ID => Data.id;
     public Data.ItemType Type => Data.itemType;
+    public Data.ItemRarity Rarity => Data.itemRarity;
     public string Name => Data.name;
-    public List<StatModifier> Modifiers { get; private set; }
+    public string Description => Data.description;
+    public float Cost => Data.cost; // TODO::
+
+    public List<StatModifier> Modifiers { get; protected set; }
+
+    #endregion
+
+    #region Fields
+
+    private bool _isInitialized;
+
+    #endregion
+
+    #region MonoBehaviours
+
+    protected virtual void Awake() {
+        Initialize();
+    }
+
+    #endregion
+
+    #region Initialize / Set
+
+    public virtual bool Initialize() {
+        if (_isInitialized) return false;
+
+        return true;
+    }
 
     public virtual void SetInfo(Data.Item data) {
+        Initialize();
+
         this.Data = data;
-        Modifiers = Data.modifiers.ConvertAll(x => x);
+        SetModifiers();
     }
+
+    protected virtual void SetModifiers() {
+        Modifiers = new();
+    }
+
+    #endregion
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/PassiveItem.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/PassiveItem.cs
@@ -1,7 +1,44 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Data;
 
 public class PassiveItem : Item {
+
+    #region Properties
+
+    public bool Stackable => (Data as Passive).stackable;
+    public int MaxStack => (Data as Passive).maxStack;
+
+    #endregion
+
+    #region Initialize / Set
+
+    public override void SetInfo(Data.Item data) {
+        base.SetInfo(data);
+    }
+
+    protected override void SetModifiers() {
+        Passive data = Data as Passive;
+
+        Modifiers = new();
+
+        switch (data.effectType) {
+            case EffectType.DamageBoost:
+                Modifiers.Add(new(StatType.Damage, StatModifierType.Add, data.numericalValue)); break;
+            case EffectType.SpeedBoost:
+                Modifiers.Add(new(StatType.Speed, StatModifierType.Add, data.numericalValue)); break;
+            case EffectType.BulletSizeBoost:
+                Modifiers.Add(new(StatType.BulletSizeX, StatModifierType.Add, data.numericalValue));
+                Modifiers.Add(new(StatType.BulletSizeY, StatModifierType.Add, data.numericalValue));
+                Modifiers.Add(new(StatType.BulletSizeZ, StatModifierType.Add, data.numericalValue));
+                break;
+            case EffectType.MagazineBoost:
+                Modifiers.Add(new(StatType.MagazineCapacity, StatModifierType.Add, data.numericalValue));
+                break;
+        }
+    }
+
+    #endregion
 
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupAmmo.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupAmmo.cs
@@ -6,6 +6,7 @@ public class PickupAmmo : PickupItem
 {
     protected override void OnPickedUp()
     {
-        Debug.Log("총알 획득");
+        if (Owner.Inventory is not PlayerInventory inventory) return;
+        inventory.EquippedWeapon.CurrentAmmo += (int)NumericalRatio;
     }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupGold.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupGold.cs
@@ -4,10 +4,8 @@ using UnityEngine;
 
 public class PickupGold : PickupItem
 {
-
-
     protected override void OnPickedUp()
     {
-        Main.Object.Player.Inventory.Gold += 100;
+        Owner.Inventory.Gold += 100;
     }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupHeart.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupHeart.cs
@@ -4,10 +4,8 @@ using UnityEngine;
 
 public class PickupHeart : PickupItem
 {
-
-
     protected override void OnPickedUp()
     {
-        Main.Object.Player.Hp += 10;
+        Owner.Hp += NumericalRatio;
     }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupItem.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/PickupItem/PickupItem.cs
@@ -2,7 +2,15 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class PickupItem : Item {
+public class PickupItem : Item {
+
+    #region Properties
+
+    public float DurationTime => (Data as Data.Pickup).durationTime;
+    public float NumericalValue => (Data as Data.Pickup).numericalValue;
+    public float NumericalRatio => (Data as Data.Pickup).numericalRatio;
+
+    #endregion
 
     [SerializeField] private LayerMask canBePickupBy;
 
@@ -19,5 +27,5 @@ public abstract class PickupItem : Item {
             }
         }
     }
-    protected abstract void OnPickedUp();
+    protected virtual void OnPickedUp() { }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/Weapon.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/Weapon.cs
@@ -7,37 +7,86 @@ using UnityEngine;
 
 public class Weapon : Item {
 
+    #region Properties
+
+    public BulletType BulletType => (Data as Data.Weapon).bulletType;
+
+    public int CurrentAmmo {
+        get => _currentAmmo;
+        set {
+            _currentAmmo = value;
+        }
+    }
+    public int CurrentMag {
+        get => _currentMag;
+        set {
+            _currentMag = value;
+        }
+    }
+
+    #endregion
+
     #region Fields
 
-    private Status _stat;
-    protected int _currentAmmo = 100;    // 현재 탄환 수
-    protected int _currentMag = 10;     // 현재 탄창에 탄환 수
+    protected int _currentAmmo;
+    protected int _currentMag;
     public Transform _bulletPivot;
     protected bool isReloading = false;
 
     #endregion
 
-    private void Awake()
+    #region MonoBehaviours
+
+    protected override void Awake()
     {
-        _currentMag = 10;//.weaponData.weapons[0].magazineCapacity;
-        _currentAmmo = 100;//weaponData.weapons[0].maxBulletAmount;
+        base.Awake();
     }
+
     private void Update()
     {
         if(Input.GetMouseButtonDown(0)) //플레이어에서 실행하는 걸로 옮길 예정
         {
-            Debug.Log(_currentMag);
+            Debug.Log(CurrentMag);
             Shoot();
             Debug.Log("Shoot");
         }
     }
+
+    #endregion
+
+    #region Initialize / Set
+
+    public override void SetInfo(Data.Item data) {
+        base.SetInfo(data);
+        CurrentMag = (int)Owner.Status[StatType.MagazineCapacity].Value;
+        CurrentAmmo = (int)Owner.Status[StatType.MaxBulletAmount].Value;
+    }
+
+    protected override void SetModifiers() {
+        Data.Weapon data = Data as Data.Weapon;
+
+        Modifiers = new() {
+            new(StatType.Damage, StatModifierType.Add, data.damage),
+            new(StatType.AttackSpeed, StatModifierType.Add, data.attackSpeed),
+            new(StatType.BulletSizeX, StatModifierType.Override, data.bulletSizeX),
+            new(StatType.BulletSizeY, StatModifierType.Override, data.bulletSizeY),
+            new(StatType.BulletSizeZ, StatModifierType.Override, data.bulletSizeZ),
+            new(StatType.ReloadTime, StatModifierType.Add, data.reloadTime),
+            new(StatType.Critical, StatModifierType.Add, data.critical),
+            new(StatType.MaxBulletAmount, StatModifierType.Add, data.maxBulletAmount),
+            new(StatType.MagazineCapacity, StatModifierType.Add, data.magazineCapacity)
+        };
+    }
+
+    #endregion 
+
     protected virtual void Shoot()
     {
         if (isReloading)
             return;
-        if (_currentMag > 0)
+        if (CurrentMag > 0)
         {
-            _currentMag --;
+            CurrentMag--;
             Main.Object.Spawn<Projectile>(1, _bulletPivot.position);
         }
         else
@@ -50,7 +99,7 @@ public class Weapon : Item {
     {
         if (isReloading)
             return;
-        if (_currentAmmo > 10)
+        if (CurrentAmmo > 10)
         {
             Reload();
         }
@@ -63,8 +112,8 @@ public class Weapon : Item {
     {
         isReloading = true;
         Task.Delay(1000);
-        _currentAmmo -= 10;
-        _currentMag = 10;
+        CurrentAmmo -= 10;
+        CurrentMag = 10;
         isReloading = false;
     }
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Items/Weapon/ShotGun.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Items/Weapon/ShotGun.cs
@@ -10,9 +10,9 @@ public class ShotGun : Weapon
         {
             return;
         }
-        if(_currentMag > 0)
+        if(CurrentMag > 0)
         {
-            _currentMag--;
+            CurrentMag--;
             float angle = 1.0f;
             float randomSpread = Random.Range(-5, 5);
             angle += randomSpread;

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Status/Stat.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Status/Stat.cs
@@ -55,6 +55,7 @@ public class Stat {
         for (int i = 0; i < _modifiers.Count; i++) {
             if (_modifiers[i].Type == StatModifierType.Add) value += _modifiers[i].Value;
             else if (_modifiers[i].Type == StatModifierType.Multiple) value *= _modifiers[i].Value;
+            else if (_modifiers[i].Type == StatModifierType.Override) value = _modifiers[i].Value;
         }
         value = Mathf.Clamp(value, Min, Max);
         return value;

--- a/TeamNotionOrigin/Assets/@Scripts/Models/Status/Status.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Models/Status/Status.cs
@@ -69,4 +69,5 @@ public enum StatType {
 public enum StatModifierType {
     Add,
     Multiple,
+    Override,
 }

--- a/TeamNotionOrigin/Assets/@Scripts/Scenes/TestScene.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Scenes/TestScene.cs
@@ -10,13 +10,14 @@ public class TestScene : BaseScene {
         //PlayerTemp player = Main.Resource.Instantiate("(Temp)Player.prefab").GetComponent<PlayerTemp>();
         //player.SetInfo(new());
 
-        Player player = Main.Object.Spawn<Player>(1, new(0, 0));
-        for (int i = 1; i <= 6; i++) {
-            Main.Object.Spawn<Monster>(i, new(i, i));
-        }
-        for (int i = 10; i < 20; i++) {
-            Main.Object.Spawn<Projectile>(i, new(i, i));
-        }
+        //Player player = Main.Object.Spawn<Player>(1, new(0, 0));
+        //for (int i = 1; i <= 6; i++) {
+        //    Main.Object.Spawn<Monster>(i, new(i, i));
+        //}
+        //for (int i = 10; i < 20; i++) {
+        //    Main.Object.Spawn<Projectile>(i, new(i, i));
+        //}
+        Debug.Log(Main.Data.ItemDict[Data.ItemType.Weapon][1].name);
 
         return true;
     }


### PR DESCRIPTION
[변경 사항]
- 아이템 데이터를 바탕으로 아이템 객체의 정보를 설정하고 접근이 쉽도록 구조를 변경했습니다. - 아이템 소유자는 해당 객체의 Owner 속성을 참조 - 아이템 ID는 해당 객체의 ID 속성을 참조 - 아이템 타입은 해당 객체의 Type 속성을 참조 - 아이템 등급은 해당 객체의 Rarity 속성을 참조 - 아이템 이름은 해당 객체의 Name 속성을 참조 - 아이템 설명은 해당 객체의 Description 속성을 참조 - 아이템 비용은 해당 객체의 Cost 속성을 참조 **TODO:: json 정보에 Cost 정보가 없는 듯 합니다! - 패시브 아이템의 stackable, maxStack 정보는 각각 해당 객체의 Stackable, MaxStack 속성을 참조 - 픽업 아이템의 durationTime, numericalValue, numericalRatio 정보는 각각 해당 객체의 어쩌구 속성 참조 - 무기의 총알 종류는 해당 객체의 BulletType 속성을 참조
- 패시브 아이템 보유 및 무기 착용에 따라 스테이터스가 변화하게 하였고, 각 정보는 소유자의 스테이터스를 참조하도록 변경했습니다. - 예를 들어 플레이어가 쏜 총알의 피해량을 알고 싶을 때는 (해당무기개체).Owner.Status[StatType.Damage].Value 참조 - 예를 들어 플레이어가 든 총의 재장전 시간을 알고 싶을 때는 (해당무기개체).Owner.Status[StatType.ReloadTime].Value 참조
- 아이템은 해당 크리쳐의 Inventory의 Add 또는 Remove 함수를 통해 크리쳐가 소유하거나 소유하지 않게 할 수 있습니다. - 패시브 아이템은 소유하는 것만으로 소유자의 Status가 갱신되며, 인벤토리에서 제거하면 Status가 갱신됩니다. - 무기 아이템은 Player만 소유할 수 있습니다. - 무기 아이템은 소유하는 것만으로는 Status가 갱신되지 않고, PlayerInventory를 통해 장비/장비해제 시 갱신됩니다. - 무기 아이템이 없을 때 무기를 추가하면 자동으로 착용합니다. - PlayerInventory.EquipWeapon(int index): index번째 무기를 착용합니다. - EquipNextWeapon(): 다음 무기를 착용합니다. - EquipPrevWeapon(): 이전 무기를 착용합니다.

[상세 변경 사항]
- Data.Item.cs: modifiers 삭제.
- Inventory.cs: Owner 속성 추가, 생성자 수정, PassiveItem 효과 적용되도록 수정, Weapon은 PlayerInventory에서 별도 관리.
- PlayerInventory.cs: 생성자 수정, Weapon 관리 코드 적용.
- Creature.cs: Inventory 생성자 수정.
- Player.cs: Inventory 생성자 수정, CurrentWeapon 속성 추가.
- Item.cs: Owner 속성 추가, Data.Item 정보 접근 속성 추가, SetModifiers 함수 추가.
- Weapon.cs: CurrentAmmo, CurrentMag 속성으로 캡슐화, SetInfo에서 초기화, SetModifiers 함수 오버라이딩.
- ShotGun.cs: _currentMag -> CurrentMag
- PassiveItem.cs: Data.Passive 정보 접근 속성 추가, SetModifiers 함수 오버라이딩.
- PickupItem.cs: Data.Pickup 정보 접근 속성 추가.
- PickupAmmo.cs: 소유자의 현재 무기의 CurrentAmmo를 NumericalRatio만큼 늘리도록 함.
- PickupGold.cs: 소유자의 골드를 100만큼 늘리도록 함.
- PickupHeart.cs: 소유자의 Hp를 NumericalRatio만큼 늘리도록 함.
- Status.cs: StatModifierType.Override 추가
- Stat.cs: StatModifierType.Override에 따른 Value 갱신 코드 추가.