### PR TITLE
[Fix] GetPrefabName

### DIFF
--- a/TeamNotionOrigin/Assets/@Scripts/Managers/ObjectManager.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Managers/ObjectManager.cs
@@ -23,7 +23,7 @@ public class ObjectManager {
 
     public T Spawn<T>(int key, Vector2 position) where T : Component {
         Type type = typeof(T);
-        string prefabName = type.Name;
+        string prefabName = GetPrefabName(type) ?? "Creature";
 
         GameObject obj = Main.Resource.Instantiate($"{prefabName}.prefab", pooling: true);
         obj.transform.position = position;
@@ -64,6 +64,25 @@ public class ObjectManager {
         }
 
         Main.Resource.Destroy(obj.gameObject);
+    }
+
+    /// <summary>
+    /// Type에 따른 프리팹 이름을 결정합니다.
+    /// Ex) type = MeleeMonster라면,
+    /// "MeleeMonster.prefab"이 존재한다면 => return "MeleeMonster";
+    /// 그렇지 않다면 부모 클래스 이름인 "Monster.prefab"이 존재한다면 => return "Monster";
+    /// 그렇지 않다면 부모 클래스 이름인 "Creature.prefab"이 존재한다면 => return "Creature";
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    private string GetPrefabName(Type type) {
+        string prefabName;
+        while (type != null) {
+            prefabName = type.Name;
+            if (Main.Resource.IsExist($"{prefabName}.prefab")) return prefabName;
+            type = type.BaseType;
+        }
+        return null;
     }
 }
 

--- a/TeamNotionOrigin/Assets/@Scripts/Managers/ResourceManager.cs
+++ b/TeamNotionOrigin/Assets/@Scripts/Managers/ResourceManager.cs
@@ -94,6 +94,10 @@ public class ResourceManager : MonoBehaviour {
         Loaded = true;
     }
 
+    public bool IsExist(string key) {
+        return _resources.ContainsKey(key);
+    }
+
     public T Load<T>(string key) where T : UnityEngine.Object {
         // key값으로 resources에 리소스가 존재하는지 확인
         if (!_resources.TryGetValue(key, out UnityEngine.Object resource))


### PR DESCRIPTION
[요약]
- MeleeMonster.prefab과 RangeMonster.prefab을 따로 만들지 않아도 Monster.prefab을 사용하여 스폰되도록 했습니다.
- Main.Object.Spawn<MeleeMonster>(...) 으로 스폰하면, MeleeMonster.prefab이 없으면 알아서 Monster.prefab을 찾아 스폰합니다.
- 사실 테스트는 안 해봤습니댜... 부탁드립니다 ㅜ [상세 변경 사항]
- ResourceManager.IsExist(string key): 해당 key를 가진 리소스가 존재하는지 확인하는 함수.
- ObjectManager.GetPrefabName(Type type): 해당 타입 또는 부모 클래스 타입들을 참조해 프리팹 이름을 결정하는 함수.